### PR TITLE
Screen widgets

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: 'true'
     - name: Get SDK Version
       shell: bash
       run: |

--- a/core/include/subsystems/screen.h
+++ b/core/include/subsystems/screen.h
@@ -102,12 +102,23 @@ namespace screen
         draw_func_t draw_f;
     };
 
+    /// Widget that updates a double value. Updates by reference so watch out for race conditions cuz the screen stuff lives on another thread
     class SliderWidget
     {
     public:
+        /// @brief Creates a slider widget
+        /// @param val reference to the value to modify
+        /// @param low minimum value to go to
+        /// @param high maximum value to go to
+        /// @param rect rect to draw it
+        /// @param name name of the value
         SliderWidget(double &val, double low, double high, Rect rect, std::string name) : value(val), low(low), high(high), rect(rect), name(name) {}
 
-        void update(bool was_pressed, int x, int y);
+        /// @brief responds to user input
+        /// @param was_pressed if the screen is pressed
+        /// @param x x position if the screen was pressed
+        /// @param y y position if the screen was pressed
+        bool update(bool was_pressed, int x, int y);
         void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number);
 
     private:
@@ -118,6 +129,26 @@ namespace screen
 
         Rect rect;
         std::string name = "";
+    };
+
+    /// Widget that updates a double value. Updates by reference so watch out for race conditions cuz the screen stuff lives on another thread
+    class ButtonWidget
+    {
+    public:
+        ButtonWidget(std::function<void(void)> onpress, Rect rect, std::string name) : onpress(onpress), rect(rect), name(name) {}
+
+        /// @brief responds to user input
+        /// @param was_pressed if the screen is pressed
+        /// @param x x position if the screen was pressed
+        /// @param y y position if the screen was pressed
+        bool update(bool was_pressed, int x, int y);
+        void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number);
+
+    private:
+        std::function<void(void)> onpress;
+        Rect rect;
+        std::string name = "";
+        bool was_pressed_last = false;
     };
 
 }

--- a/core/include/subsystems/screen.h
+++ b/core/include/subsystems/screen.h
@@ -33,7 +33,7 @@ namespace screen
                           unsigned int frame_number);
     };
 
-    /// Widget that updates a double value. Updates by reference so watch out for race conditions cuz the screen stuff lives on another thread
+    /// @brief Widget that updates a double value. Updates by reference so watch out for race conditions cuz the screen stuff lives on another thread
     class SliderWidget
     {
     public:
@@ -49,7 +49,9 @@ namespace screen
         /// @param was_pressed if the screen is pressed
         /// @param x x position if the screen was pressed
         /// @param y y position if the screen was pressed
+        /// @return true if the value updated
         bool update(bool was_pressed, int x, int y);
+        /// @brief @ref Page::draws the slide to the screen
         void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number);
 
     private:
@@ -62,18 +64,28 @@ namespace screen
         std::string name = "";
     };
 
-    /// Widget that updates a double value. Updates by reference so watch out for race conditions cuz the screen stuff lives on another thread
+    /// @brief Widget that does something when you tap it. The function is only called once when you first tap it
     class ButtonWidget
     {
     public:
+        /// @brief Create a Button widget
+        /// @param onpress the function to be called when the button is tapped
+        /// @param rect the area the button should take up on the screen
+        /// @param name the label put on the button
         ButtonWidget(std::function<void(void)> onpress, Rect rect, std::string name) : onpress(onpress), rect(rect), name(name) {}
+        /// @brief Create a Button widget
+        /// @param onpress the function to be called when the button is tapped
+        /// @param rect the area the button should take up on the screen
+        /// @param name the label put on the button
         ButtonWidget(void (*onpress)(), Rect rect, std::string name) : onpress(onpress), rect(rect), name(name) {}
 
         /// @brief responds to user input
         /// @param was_pressed if the screen is pressed
         /// @param x x position if the screen was pressed
         /// @param y y position if the screen was pressed
+        /// @return true if the button was pressed
         bool update(bool was_pressed, int x, int y);
+        /// @brief draws the button to the screen
         void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number);
 
     private:
@@ -100,11 +112,17 @@ namespace screen
     /// @brief  type of function needed for draw
     using draw_func_t = std::function<void(vex::brain::lcd &screen, bool, unsigned int)>;
 
+
+    /// @brief Draws motor stats and battery stats to the screen 
     class StatsPage : public Page
     {
     public:
+        /// @brief Creates a stats page
+        /// @param motors a map of string to motor that we want to draw on this page
         StatsPage(std::map<std::string, vex::motor &> motors);
+        /// @brief @see Page#update
         void update(bool was_pressed, int x, int y) override;
+        /// @brief @see Page#draw
         void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number) override;
 
     private:
@@ -129,9 +147,9 @@ namespace screen
         /// @param robot_height the robot_height (front to back) of the robot in inches. Used for visualization
         /// @param do_trail whether or not to calculate and draw the trail. Drawing and storing takes a very *slight* extra amount of processing power 
         OdometryPage(OdometryBase &odom, double robot_width, double robot_height, bool do_trail);
-        /// @brief draw the page
+        /// @brief @see Page#update
         void update(bool was_pressed, int x, int y) override;
-        /// @brief draw the page
+        /// @brief @see Page#draw
         void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number) override;
 
     private:
@@ -152,10 +170,13 @@ namespace screen
     class FunctionPage : public Page
     {
     public:
+        /// @brief Creates a function page
+        /// @param update_f the function called every tick to respond to user input or do data collection
+        /// @param draw_t the function called to draw to the screen
         FunctionPage(update_func_t update_f, draw_func_t draw_t);
-        /// @brief update the page
+        /// @brief @see Page#update
         void update(bool was_pressed, int x, int y) override;
-        /// @brief draw the page
+        /// @brief @see Page#draw
         void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number) override;
 
     private:
@@ -173,9 +194,9 @@ namespace screen
         /// @param onchange a function that is called when a tuning parameter is changed. If you need to update stuff on that change register a handler here
         PIDPage(PID *pid, std::string name, std::function<void(void)> onchange);
 
-        /// @brief update the page
+        /// @brief @see Page#update
         void update(bool was_pressed, int x, int y) override;
-        /// @brief draw the page
+        /// @brief @see Page#draw
         void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number) override;
 
     private:

--- a/core/include/subsystems/screen.h
+++ b/core/include/subsystems/screen.h
@@ -192,7 +192,7 @@ namespace screen
         /// @param pid the pid controller we're changing
         /// @param name a name to recognize this pid controller if we've got multiple pid screens
         /// @param onchange a function that is called when a tuning parameter is changed. If you need to update stuff on that change register a handler here
-        PIDPage(PID *pid, std::string name, std::function<void(void)> onchange);
+        PIDPage(PID *pid, std::string name, std::function<void(void)> onchange = [](){});
 
         /// @brief @see Page#update
         void update(bool was_pressed, int x, int y) override;

--- a/core/include/subsystems/screen.h
+++ b/core/include/subsystems/screen.h
@@ -66,7 +66,7 @@ namespace screen
 
     /**
      * @brief a page that shows odometry position and rotation and a map (if an sd card with the file is on)
-    */
+     */
     class OdometryPage : public Page
     {
     public:
@@ -85,7 +85,7 @@ namespace screen
         int buf_size = 0;
         pose_t path[path_len];
         int path_index = 0;
-        bool do_trail;        
+        bool do_trail;
     };
 
     /// @brief Simple page that stores no internal data. the draw and update functions use only global data rather than storing anything
@@ -100,6 +100,24 @@ namespace screen
     private:
         update_func_t update_f;
         draw_func_t draw_f;
+    };
+
+    class SliderWidget
+    {
+    public:
+        SliderWidget(double &val, double low, double high, Rect rect, std::string name) : value(val), low(low), high(high), rect(rect), name(name) {}
+
+        void update(bool was_pressed, int x, int y);
+        void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number);
+
+    private:
+        double &value;
+
+        double low;
+        double high;
+
+        Rect rect;
+        std::string name = "";
     };
 
 }

--- a/core/include/subsystems/screen.h
+++ b/core/include/subsystems/screen.h
@@ -169,7 +169,7 @@ namespace screen
               zero_d([this]()
                      { zero_d_f(); },
                      Rect{{180, 140}, {220, 180}}, "0"),
-              graph(40, 0, 0, {vex::red, vex::green}, 2)
+              graph(40, -30, 120, {vex::red, vex::green}, 2)
         {
             assert(pid != nullptr);
         }

--- a/core/include/utils/auto_chooser.h
+++ b/core/include/utils/auto_chooser.h
@@ -21,7 +21,7 @@ public:
    * so the driver can choose which autonomous to run.
    * @param brain the brain on which to draw the selection boxes
    */
-  AutoChooser(std::vector<std::string> paths);
+  AutoChooser(std::vector<std::string> paths, size_t def = 0);
 
   void update(bool was_pressed, int x, int y);
   void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number);
@@ -30,7 +30,7 @@ public:
    * Get the currently selected auto choice
    * @return the identifier to the auto path
    */
-  std::string get_choice();
+  size_t get_choice();
 
 protected:
   /**
@@ -45,6 +45,6 @@ protected:
   static const size_t width = 380;
   static const size_t height = 220;
 
-  std::string choice; /**< the current choice of auto*/
+  size_t choice; /**< the current choice of auto*/
   std::vector<entry_t> list /**< a list of all possible auto choices*/;
 };

--- a/core/include/utils/auto_chooser.h
+++ b/core/include/utils/auto_chooser.h
@@ -2,57 +2,49 @@
 #include "vex.h"
 #include <string>
 #include <vector>
-
+#include "../core/include/subsystems/screen.h"
+#include "../core/include/utils/geometry.h"
 
 /**
  * Autochooser is a utility to make selecting robot autonomous programs easier
  * source: RIT VexU Wiki
- * During a season, we usually code between 4 and 6 autonomous programs. 
+ * During a season, we usually code between 4 and 6 autonomous programs.
  * Most teams will change their entire robot program as a way of choosing autonomi
- * but this may cause issues if you have an emergency patch to upload during a competition. 
+ * but this may cause issues if you have an emergency patch to upload during a competition.
  * This class was built as a way of using the robot screen to list autonomous programs, and the touchscreen to select them.
  */
-class AutoChooser
+class AutoChooser : public screen::Page
 {
-  public:
-/**
-  * Initialize the auto-chooser. This class places a choice menu on the brain screen,
-  * so the driver can choose which autonomous to run.
-  * @param brain the brain on which to draw the selection boxes
-  */
-  AutoChooser(vex::brain &brain);
-  
+public:
   /**
-   * Add an auto path to the chooser
-   * @param name The name of the path. This should be used as an human readable identifier to the auto path
-  */
-  void add(std::string name);
+   * Initialize the auto-chooser. This class places a choice menu on the brain screen,
+   * so the driver can choose which autonomous to run.
+   * @param brain the brain on which to draw the selection boxes
+   */
+  AutoChooser(std::vector<std::string> paths);
+
+  void update(bool was_pressed, int x, int y);
+  void draw(vex::brain::lcd &, bool first_draw, unsigned int frame_number);
 
   /**
    * Get the currently selected auto choice
    * @return the identifier to the auto path
-  */
+   */
   std::string get_choice();
 
-  protected:
-
+protected:
   /**
    *  entry_t is a datatype used to store information that the chooser knows about an auto selection button
-   */ 
+   */
   struct entry_t
   {
-    int x; /**< screen x position of the block*/ 
-    int y; /**< screen y position of the block*/ 
-    int width; /**< width of the block*/ 
-    int height; /**< height of the block*/ 
-    std::string name; /**< name of the auto repretsented by the block*/ 
+    Rect rect;
+    std::string name; /**< name of the auto repretsented by the block*/
   };
 
-  void render(entry_t *selected);
+  static const size_t width = 380;
+  static const size_t height = 220;
 
   std::string choice; /**< the current choice of auto*/
   std::vector<entry_t> list /**< a list of all possible auto choices*/;
-  vex::brain &brain; /**< the brain to show the choices on*/
-
-
 };

--- a/core/include/utils/geometry.h
+++ b/core/include/utils/geometry.h
@@ -89,17 +89,23 @@ struct Rect
 {
     point_t min;
     point_t max;
+    static Rect from_min_and_size(point_t min, point_t size){
+        return {min, min+size};
+    }
     point_t dimensions() const
     {
         return max - min;
     }
-    double weight() const{
+    point_t center() const{
+        return (min + max)/2;
+    }
+    double width() const{
         return max.x - min.x;
     }
     double height() const{
         return max.y - min.y;
     }
-    bool contains(point_t p)
+    bool contains(point_t p) const
     {
         bool xin = p.x > min.x && p.x < max.x;
         bool yin = p.y > min.y && p.y < max.y;

--- a/core/include/utils/geometry.h
+++ b/core/include/utils/geometry.h
@@ -24,7 +24,7 @@ struct point_t
      * @param other the point to add on to this
      * @return this + other (this.x + other.x, this.y + other.y)
      */
-    point_t operator+(const point_t &other)
+    point_t operator+(const point_t &other) const
     {
         point_t p{
             .x = this->x + other.x,
@@ -37,7 +37,7 @@ struct point_t
      * @param other the point_t to subtract from this
      * @return this - other (this.x - other.x, this.y - other.y)
      */
-    point_t operator-(const point_t &other)
+    point_t operator-(const point_t &other) const
     {
         point_t p{
             .x = this->x - other.x,
@@ -84,6 +84,29 @@ typedef struct
     }
 
 } pose_t;
+
+struct Rect
+{
+    point_t min;
+    point_t max;
+    point_t dimensions() const
+    {
+        return max - min;
+    }
+    double weight() const{
+        return max.x - min.x;
+    }
+    double height() const{
+        return max.y - min.y;
+    }
+    bool contains(point_t p)
+    {
+        bool xin = p.x > min.x && p.x < max.x;
+        bool yin = p.y > min.y && p.y < max.y;
+        return xin && yin;
+    }
+
+};
 
 struct Mat2
 {

--- a/core/include/utils/geometry.h
+++ b/core/include/utils/geometry.h
@@ -72,7 +72,7 @@ struct point_t
 /**
  *  Describes a single position and rotation
  */
-typedef struct
+struct pose_t
 {
     double x;   ///< x position in the world
     double y;   ///< y position in the world
@@ -83,7 +83,7 @@ typedef struct
         return point_t{.x = x, .y = y};
     }
 
-} pose_t;
+} ;
 
 struct Rect
 {

--- a/core/include/utils/graph_drawer.h
+++ b/core/include/utils/graph_drawer.h
@@ -11,23 +11,25 @@
 class GraphDrawer
 {
 public:
+  /// @brief Creates a graph drawer with the specified number of series (each series is a separate line)
+  /// @param num_samples the number of samples to graph at a time (40 will graph the last 40 data points)
+  /// @param lower_bound the bottom of the window when displaying (if upper_bound = lower_bound, auto calculate bounds)
+  /// @param upper_bound the top of the window when displaying (if upper_bound = lower_bound, auto calculate bounds)
+  /// @param colors the colors of the series. must be of size num_series
+  /// @param num_series the number of series to graph
+  GraphDrawer(int num_samples, double lower_bound, double upper_bound, std::vector<vex::color> colors, size_t num_series = 1);
   /**
-   * Construct a GraphDrawer
-   * @brief a helper class to graph values on the brain screen
-   * @param screen a reference to Brain.screen we can save for later
-   * @param num_samples the graph works on a fixed window and will plot the last `num_samples` before the history is forgotten. Larger values give more context but may slow down if you have many graphs or an exceptionally high
-   * @param x_label the name of the x axis (currently unused)
-   * @param y_label the name of the y axis (currently unused)
-   * @param draw_border whether to draw the border around the graph. can be turned off if there are multiple graphs in the same space ie. a graph of error and output
-   * @param lower_bound the bottom of the window to graph. if lower_bound == upperbound, the graph will scale to it's datapoints
-   * @param upper_bound the top of the window to graph. if lower_bound == upperbound, the graph will scale to it's datapoints
-   */
-  GraphDrawer(vex::brain::lcd &screen, int num_samples, std::string x_label, std::string y_label, vex::color col, bool draw_border, double lower_bound, double upper_bound);
-  /**
-   * add_sample adds a point to the graph, removing one from the back
+   * add_samples adds a point to the graph, removing one from the back
    * @param sample an x, y coordinate of the next point to graph
    */
-  void add_sample(point_t sample);
+  void add_samples(std::vector<point_t> sample);
+
+  /**
+   * add_samples adds a point to the graph, removing one from the back
+   * @param sample a y coordinate of the next point to graph, the x coordinate is gotten from vex::timer::system(); (time in ms)
+   */
+  void add_samples(std::vector<double> sample);
+
   /**
    * draws the graph to the screen in the constructor
    * @param x x position of the top left of the graphed region
@@ -35,17 +37,15 @@ public:
    * @param width the width of the graphed region
    * @param height the height of the graphed region
    */
-  void draw(int x, int y, int width, int height);
+  void draw(vex::brain::lcd &screen, int x, int y, int width, int height);
 
 private:
-  vex::brain::lcd &Screen;
-  std::vector<point_t> samples;
+  std::vector<std::vector<point_t>> series;
   int sample_index = 0;
-  std::string xlabel;
-  std::string ylabel;
-  vex::color col = vex::red;
+  std::vector<vex::color> cols;
   vex::color bgcol = vex::transparent;
   bool border;
   double upper;
   double lower;
+  bool auto_fit = false;
 };

--- a/core/include/utils/logger.h
+++ b/core/include/utils/logger.h
@@ -26,7 +26,7 @@ private:
 
 public:
     /// @brief  maximum size for a string to be before it's written
-    const int MAX_FORMAT_LEN = 512;
+    static constexpr int MAX_FORMAT_LEN = 512;
     /// @brief  Create a logger that will save to a file
     /// @param filename the file to save to
     explicit Logger(const std::string &filename);

--- a/core/include/utils/pid.h
+++ b/core/include/utils/pid.h
@@ -74,6 +74,14 @@ public:
    */
   double update(double sensor_val) override;
 
+  
+  /**
+   * @brief gets the sensor value that we were last updated with
+   * @return sensor_val
+  */
+  double get_sensor_val();
+
+
   /**
    * Gets the current PID out value, from when update() was last run
    * @return the Out value of the controller (voltage, RPM, whatever the PID controller is controlling)

--- a/core/include/utils/serializer.h
+++ b/core/include/utils/serializer.h
@@ -4,11 +4,12 @@
 #include <string>
 #include <vector>
 #include <stdio.h>
+#include <vex.h>
 
 /// @brief character that will be used to seperate values
 const char serialization_separator = '$';
 /// @brief max file size that the system can deal with
-const std::size_t MAX_FILE_SIZE = 4096; 
+const std::size_t MAX_FILE_SIZE = 4096;
 
 /// @brief Serializes Arbitrary data to a file on the SD Card
 class Serializer
@@ -36,7 +37,11 @@ public:
     /// @brief create a Serializer
     /// @param filename the file to read from. If filename does not exist we will create that file
     /// @param flush_always If true, after every write flush to a file. If false, you are responsible for calling save_to_disk
-    explicit Serializer(const std::string &filename, bool flush_always = true) : flush_always(flush_always), filename(filename), ints({}), bools({}), doubles({}), strings({}) { read_from_disk(); }
+    explicit Serializer(const std::string &filename, bool flush_always = true) : flush_always(flush_always), filename(filename), ints({}), bools({}), doubles({}), strings({})
+
+    {
+        read_from_disk();
+    }
 
     /// @brief saves current Serializer state to disk
     void save_to_disk() const;

--- a/core/src/subsystems/screen.cpp
+++ b/core/src/subsystems/screen.cpp
@@ -413,8 +413,6 @@ namespace screen
         graph.draw(scr, 230, 20, 200, 200);
 
         scr.setPenColor(vex::white);
-        
-        printf(": %s\n", name.c_str());
         scr.printAt(60, 215, false, "%s", name.c_str());
     }
 

--- a/core/src/subsystems/screen.cpp
+++ b/core/src/subsystems/screen.cpp
@@ -192,6 +192,8 @@ namespace screen
         int num = 0;
         int x = 40;
         int y = y_start + row_height;
+        scr.setPenWidth(1);
+
         scr.drawRectangle(x, y_start, row_width, row_height);
         scr.printAt(x, y_start + 16, false, " port temp  name");
         for (auto &kv : motors)
@@ -329,12 +331,13 @@ namespace screen
     }
     void SliderWidget::draw(vex::brain::lcd &scr, bool first_draw, unsigned int frame_number)
     {
-        if (rect.height() <= 0){
+        if (rect.height() <= 0)
+        {
             printf("Slider: %s has no height. Cant use it.", name.c_str());
         }
         double xl = rect.min.x;
         double xh = rect.max.x;
-        double xmid = (xl + xh)/2.0;
+        double xmid = (xl + xh) / 2.0;
         double y = rect.min.y + rect.height() / 2;
         const double margin = 5.0;
 
@@ -350,6 +353,6 @@ namespace screen
         const double handle_height = 4;
         scr.drawRectangle(vx - (handle_width / 2), y - (handle_height / 2), handle_width, handle_height);
         int text_w = scr.getStringWidth((name + "      ").c_str());
-        scr.printAt(xmid - text_w/2, y - 30, false, "%s: %.2f", name.c_str(), value);
+        scr.printAt(xmid - text_w / 2, y - 30, false, "%s: %.2f", name.c_str(), value);
     }
 } // namespace screen

--- a/core/src/subsystems/screen.cpp
+++ b/core/src/subsystems/screen.cpp
@@ -373,7 +373,7 @@ namespace screen
             return true;
         }
         was_pressed_last = was_pressed;
-        return true;
+        return false;
     }
 
     void ButtonWidget::draw(vex::brain::lcd &scr, bool first_draw [[maybe_unused]], unsigned int frame_number [[maybe_unused]])
@@ -385,6 +385,37 @@ namespace screen
         int w = scr.getStringWidth(name.c_str());
         int h = scr.getStringHeight(name.c_str());
         scr.printAt(rect.center().x - w / 2, rect.center().y + h / 2, name.c_str());
+    }
+    void PIDPage::update(bool was_pressed, int x, int y)
+    {
+        bool updated = false;
+        updated |= p_slider.update(was_pressed, x, y);
+        updated |= i_slider.update(was_pressed, x, y);
+        updated |= d_slider.update(was_pressed, x, y);
+
+        updated |= zero_i.update(was_pressed, x, y);
+        updated |= zero_d.update(was_pressed, x, y);
+        if (updated)
+        {
+            onchange();
+        }
+    }
+    void PIDPage::draw(vex::brain::lcd &scr, bool first_draw [[maybe_unused]], unsigned int frame_number [[maybe_unused]])
+    {
+        p_slider.draw(scr, first_draw, frame_number);
+        i_slider.draw(scr, first_draw, frame_number);
+        d_slider.draw(scr, first_draw, frame_number);
+        zero_i.draw(scr, first_draw, frame_number);
+        zero_d.draw(scr, first_draw, frame_number);
+
+        graph.add_samples({pid->get_target(), pid->get_sensor_val()});
+
+        graph.draw(scr, 230, 20, 200, 200);
+
+        scr.setPenColor(vex::white);
+        
+        printf(": %s\n", name.c_str());
+        scr.printAt(60, 215, false, "%s", name.c_str());
     }
 
 } // namespace screen

--- a/core/src/subsystems/screen.cpp
+++ b/core/src/subsystems/screen.cpp
@@ -1,5 +1,5 @@
 #include "../core/include/subsystems/screen.h"
-
+#include "../core/include/utils/math_util.h"
 namespace screen
 {
     /**
@@ -309,5 +309,47 @@ namespace screen
         (void)x;
         (void)y;
         (void)was_pressed;
+    }
+
+    void SliderWidget::update(bool was_pressed, int x, int y)
+    {
+        const double margin = 10.0;
+
+        if (was_pressed)
+        {
+            double dx = x;
+            double dy = y;
+            if (rect.contains(point_t{dx, dy}))
+            {
+                double pct = (dx - rect.min.x - margin) / (rect.dimensions().x - 2 * margin);
+                pct = clamp(pct, 0.0, 1.0);
+                value = (low + pct * (high - low));
+            }
+        }
+    }
+    void SliderWidget::draw(vex::brain::lcd &scr, bool first_draw, unsigned int frame_number)
+    {
+        if (rect.height() <= 0){
+            printf("Slider: %s has no height. Cant use it.", name.c_str());
+        }
+        double xl = rect.min.x;
+        double xh = rect.max.x;
+        double xmid = (xl + xh)/2.0;
+        double y = rect.min.y + rect.height() / 2;
+        const double margin = 5.0;
+
+        scr.setPenColor(vex::color(50, 50, 50));
+        scr.setFillColor(vex::color(50, 50, 50));
+        scr.drawRectangle(rect.min.x, rect.min.y, rect.dimensions().x, rect.dimensions().y);
+        scr.setPenColor(vex::color(200, 200, 200));
+        scr.setPenWidth(4);
+        scr.drawLine(xl + margin, y, xh - margin, y);
+        double pct = (value - low) / (high - low);
+        double vx = pct * (rect.dimensions().x - (2 * margin)) + rect.min.x + margin;
+        const double handle_width = 4;
+        const double handle_height = 4;
+        scr.drawRectangle(vx - (handle_width / 2), y - (handle_height / 2), handle_width, handle_height);
+        int text_w = scr.getStringWidth((name + "      ").c_str());
+        scr.printAt(xmid - text_w/2, y - 30, false, "%s: %.2f", name.c_str(), value);
     }
 } // namespace screen

--- a/core/src/utils/auto_chooser.cpp
+++ b/core/src/utils/auto_chooser.cpp
@@ -1,87 +1,69 @@
 #include "../core/include/utils/auto_chooser.h"
 
 /**
-  * Initialize the auto-chooser. This class places a choice menu on the brain screen,
-  * so the driver can choose which autonomous to run.
-  * @param brain the brain on which to draw the selection boxes
-  */
-AutoChooser::AutoChooser(vex::brain &brain) : brain(brain)
+ * Initialize the auto-chooser. This class places a choice menu on the brain screen,
+ * so the driver can choose which autonomous to run.
+ * @param brain the brain on which to draw the selection boxes
+ */
+AutoChooser::AutoChooser(std::vector<std::string> paths)
 {
-  brain.Screen.pressed([](void *ptr){
-    AutoChooser &a = *(AutoChooser*)ptr;
-    int x = a.brain.Screen.xPosition();
-    int y = a.brain.Screen.yPosition();
+  const static int per_line = 3;
+  const static int num_lines = 2;
+  const static int x_padding = 20;
+  const static int y_padding = 20;
 
-    entry_t *selected = NULL;
-    
-    // Check if the touchscreen press is inside each rectangle
-    for(int i = 0; i < a.list.size(); i++)
+  const int entry_height = ((height - (y_padding * (num_lines - 1))) / num_lines);
+  const int entry_width = ((width - (x_padding * (per_line - 1))) / per_line);
+
+  list = std::vector<entry_t>(paths.size());
+  int x = 50;
+  int y = 10;
+  for (size_t i = 0; i < list.size(); i++)
+  {
+    Rect r = Rect::from_min_and_size({(double)x, (double)y}, {entry_width, entry_height});
+    list[i] = entry_t{r, paths[i]};
+    x += entry_width + x_padding;
+    if ((i + 1) % per_line == 0)
     {
-      int rect_x = a.list[i].x, rect_y = a.list[i].y;
-      int rect_w = a.list[i].width, rect_h = a.list[i].height;
-      if (x > rect_x && x < rect_x + rect_w)
-        if (y > rect_y && y < rect_y + rect_h)
-          selected = &a.list[i];
+      y += entry_height + y_padding;
+      x = 50;
     }
-
-    // Re-render all the choices on each press.
-    a.render(selected);
-    
-    if(selected == NULL)
-      a.choice = "";
-    else
-      a.choice = selected->name;
-
-  }, this);
+  }
+}
+void AutoChooser::update(bool was_pressed, int x, int y)
+{
+  for (const entry_t &e : list)
+  {
+    if (e.rect.contains({(double)x, (double)y}))
+    {
+      choice = e.name;
+    }
+  }
 }
 
-#define PADDING 10
-#define WIDTH 150
-#define HEIGHT 40
-
-/**
-  * Place all the autonomous choices on the screen.
-  * If one is selected, change it's color
-  * @param selected the choice that is currently selected
-  */
-void AutoChooser::render(entry_t *selected)
+void AutoChooser::draw(vex::brain::lcd &scr, bool first_draw, unsigned int frame_number)
 {
-  for(int i = 0; i < list.size(); i++)
-  {
-    brain.Screen.setPenColor(vex::color::black);
-  
-    if(selected != NULL && selected == &list[i])
-      brain.Screen.setFillColor(vex::color::white);
-    else
-      brain.Screen.setFillColor(vex::color::orange);
+  scr.setFont(vex::fontType::mono20);
 
-    brain.Screen.drawRectangle(list[i].x, list[i].y, list[i].width, list[i].height);
-    brain.Screen.printAt(list[i].x + PADDING, list[i].y + list[i].height - PADDING, list[i].name.c_str());
+  for (size_t i = 0; i < list.size(); i++)
+  {
+    entry_t e = list[i];
+    scr.setFillColor(vex::blue);
+
+    if (choice == e.name)
+    {
+      scr.setFillColor(vex::green);
+    }
+    scr.drawRectangle(e.rect.min.x, e.rect.min.y, e.rect.width(), e.rect.height());
+
+    int width = scr.getStringWidth(e.name.c_str());
+    scr.printAt(e.rect.center().x - width / 2, e.rect.center().y - 10, e.name.c_str());
   }
 }
 
 /**
-  * Add a new autonomous option. There are 3 options per row.
-  */
-void AutoChooser::add(std::string name)
-{
-  int x = (PADDING * ((list.size() % 3) + 1)) + ((list.size() % 3) * WIDTH);
-  int y = (PADDING * ((list.size() / 3) + 1)) + ((list.size() / 3) * HEIGHT);
-  entry_t entry = {
-    .x=x,
-    .y=y,
-    .width=WIDTH,
-    .height=HEIGHT,
-    .name=name
-  };
-
-  list.push_back(entry);
-  render(NULL);
-}
-
-/**
-  * Return the selected autonomous
-  */
+ * Return the selected autonomous
+ */
 std::string AutoChooser::get_choice()
 {
   return choice;

--- a/core/src/utils/auto_chooser.cpp
+++ b/core/src/utils/auto_chooser.cpp
@@ -35,7 +35,7 @@ void AutoChooser::update(bool was_pressed, int x, int y)
   size_t i = 0;
   for (const entry_t &e : list)
   {
-    if (e.rect.contains({(double)x, (double)y}))
+    if (was_pressed && e.rect.contains({(double)x, (double)y}))
     {
       choice = i;
     }

--- a/core/src/utils/auto_chooser.cpp
+++ b/core/src/utils/auto_chooser.cpp
@@ -5,7 +5,7 @@
  * so the driver can choose which autonomous to run.
  * @param brain the brain on which to draw the selection boxes
  */
-AutoChooser::AutoChooser(std::vector<std::string> paths)
+AutoChooser::AutoChooser(std::vector<std::string> paths, size_t def) : choice(def)
 {
   const static int per_line = 3;
   const static int num_lines = 2;
@@ -32,16 +32,18 @@ AutoChooser::AutoChooser(std::vector<std::string> paths)
 }
 void AutoChooser::update(bool was_pressed, int x, int y)
 {
+  size_t i = 0;
   for (const entry_t &e : list)
   {
     if (e.rect.contains({(double)x, (double)y}))
     {
-      choice = e.name;
+      choice = i;
     }
+    i++;
   }
 }
 
-void AutoChooser::draw(vex::brain::lcd &scr, bool first_draw, unsigned int frame_number)
+void AutoChooser::draw(vex::brain::lcd &scr, [[maybe_unused]] bool first_draw, [[maybe_unused]] unsigned int frame_number)
 {
   scr.setFont(vex::fontType::mono20);
 
@@ -50,7 +52,7 @@ void AutoChooser::draw(vex::brain::lcd &scr, bool first_draw, unsigned int frame
     entry_t e = list[i];
     scr.setFillColor(vex::blue);
 
-    if (choice == e.name)
+    if (choice == i)
     {
       scr.setFillColor(vex::green);
     }
@@ -64,7 +66,7 @@ void AutoChooser::draw(vex::brain::lcd &scr, bool first_draw, unsigned int frame
 /**
  * Return the selected autonomous
  */
-std::string AutoChooser::get_choice()
+size_t AutoChooser::get_choice() 
 {
   return choice;
 }

--- a/core/src/utils/graph_drawer.cpp
+++ b/core/src/utils/graph_drawer.cpp
@@ -22,6 +22,9 @@ GraphDrawer::GraphDrawer(int num_samples, double lower_bound, double upper_bound
     {
         upper = -1000.0;
         lower = 1000.0;
+    } else {
+        upper = upper_bound;
+        lower = lower_bound;
     }
 }
 
@@ -111,6 +114,7 @@ void GraphDrawer::draw(vex::brain::lcd &screen, int x, int y, int width, int hei
     double sample_range = upper - lower;
     screen.setPenWidth(2);
 
+    printf("low: %f high: %f\n", lower, upper);
     for (int j = 0; j < series.size(); j++)
     {
         double x_s = (double)x;

--- a/core/src/utils/graph_drawer.cpp
+++ b/core/src/utils/graph_drawer.cpp
@@ -114,7 +114,6 @@ void GraphDrawer::draw(vex::brain::lcd &screen, int x, int y, int width, int hei
     double sample_range = upper - lower;
     screen.setPenWidth(2);
 
-    printf("low: %f high: %f\n", lower, upper);
     for (int j = 0; j < series.size(); j++)
     {
         double x_s = (double)x;

--- a/core/src/utils/graph_drawer.cpp
+++ b/core/src/utils/graph_drawer.cpp
@@ -91,7 +91,7 @@ void GraphDrawer::draw(int x, int y, int width, int height)
     double sample_range = current_max - current_min;
     double x_s = (double)x;
     double y_s = (double)y + (double)height;
-    Screen.setPenWidth(4);
+    Screen.setPenWidth(2);
     Screen.setPenColor(col);
     for (int i = sample_index; i < samples.size() + sample_index - 1; i++)
     {

--- a/core/src/utils/graph_drawer.cpp
+++ b/core/src/utils/graph_drawer.cpp
@@ -1,31 +1,70 @@
 #include "../core/include/utils/graph_drawer.h"
 
-/**
- * Construct a GraphDrawer
- * @brief a helper class to graph values on the brain screen
- * @param screen a reference to Brain.screen we can save for later
- * @param num_samples the graph works on a fixed window and will plot the last `num_samples` before the history is forgotten. Larger values give more context but may slow down if you have many graphs or an exceptionally high
- * @param x_label the name of the x axis (currently unused)
- * @param y_label the name of the y axis (currently unused)
- * @param draw_border whether to draw the border around the graph. can be turned off if there are multiple graphs in the same space ie. a graph of error and output
- * @param lower_bound the bottom of the window to graph. if lower_bound == upperbound, the graph will scale to it's datapoints
- * @param upper_bound the top of the window to graph. if lower_bound == upperbound, the graph will scale to it's datapoints
- */
-GraphDrawer::GraphDrawer(vex::brain::lcd &screen, int num_samples, std::string x_label, std::string y_label, vex::color col, bool draw_border, double lower_bound, double upper_bound) : Screen(screen), sample_index(0), xlabel(x_label), ylabel(y_label), col(col), border(draw_border), upper(upper_bound), lower(lower_bound)
+/// @brief Creates a graph drawer with the specified number of series (each series is a separate line)
+/// @param num_samples the number of samples to graph at a time (40 will graph the last 40 data points)
+/// @param lower_bound the bottom of the window when displaying (if upper_bound = lower_bound, auto calculate bounds)
+/// @param upper_bound the top of the window when displaying (if upper_bound = lower_bound, auto calculate bounds)
+/// @param colors the colors of the series. must be of size num_series
+/// @param num_series the number of series to graph
+GraphDrawer::GraphDrawer(int num_samples, double lower_bound, double upper_bound, std::vector<vex::color> colors, size_t num_series) : cols(colors), auto_fit(lower_bound == upper_bound)
 {
-    std::vector<point_t> temp(num_samples, point_t{.x = 0.0, .y = 0.0});
-    samples = temp;
+    if (colors.size() != num_series)
+    {
+        printf("The number of colors does not match the number of series in graph drawer\n");
+    }
+    series = std::vector<std::vector<point_t>>(num_series);
+    for (size_t i = 0; i < num_series; i++)
+    {
+        series[i] = std::vector<point_t>(num_samples, {0.0, 0.0});
+    }
+
+    if (auto_fit)
+    {
+        upper = -1000.0;
+        lower = 1000.0;
+    }
 }
 
 /**
- * add_sample adds a point to the graph, removing one from the back
+ * add_samples adds a point to the graph, removing one from the back
  * @param sample an x, y coordinate of the next point to graph
  */
-void GraphDrawer::add_sample(point_t sample)
+void GraphDrawer::add_samples(std::vector<point_t> new_samples)
 {
-    samples[sample_index] = sample;
+    if (series.size() != new_samples.size())
+    {
+        printf("Mismatch between # of samples given and number of series. %s : %d\n", __FILE__, __LINE__);
+    }
+    for (size_t i = 0; i < series.size(); i++)
+    {
+        series[i][sample_index] = new_samples[i];
+        if (auto_fit)
+        {
+            upper = fmax(upper, new_samples[i].y);
+            lower = fmin(lower, new_samples[i].y);
+        }
+    }
     sample_index++;
-    sample_index %= samples.size();
+    sample_index %= series[0].size();
+}
+
+void GraphDrawer::add_samples(std::vector<double> new_samples)
+{
+    if (series.size() != new_samples.size())
+    {
+        printf("Mismatch between # of samples given and number of series. %s : %d\n", __FILE__, __LINE__);
+    }
+    for (size_t i = 0; i < series.size(); i++)
+    {
+        series[i][sample_index] = {(double)vex::timer::system(), new_samples[i]};
+        if (auto_fit)
+        {
+            upper = fmax(upper, new_samples[i]);
+            lower = fmin(lower, new_samples[i]);
+        }
+    }
+    sample_index++;
+    sample_index %= series[0].size();
 }
 
 /**
@@ -35,74 +74,61 @@ void GraphDrawer::add_sample(point_t sample)
  * @param width the width of the graphed region
  * @param height the height of the graphed region
  */
-void GraphDrawer::draw(int x, int y, int width, int height)
+void GraphDrawer::draw(vex::brain::lcd &screen, int x, int y, int width, int height)
 {
-    if (samples.size() < 1)
+    if (series[0].size() < 1)
     {
         return;
     }
-
-    double current_min = samples[0].y;
-    double current_max = samples[0].y;
-    double earliest_time = samples[0].x;
-    double latest_time = samples[0].x;
-    // collect data
-    for (int i = 0; i < samples.size(); i++)
+    if (cols.size() != series.size())
     {
-        point_t p = samples[i];
-        if (p.x < earliest_time)
-        {
-            earliest_time = p.x;
-        }
-        else if (p.x > latest_time)
-        {
-            latest_time = p.x;
-        }
-
-        if (p.y < current_min)
-        {
-            current_min = p.y;
-        }
-        else if (p.y > current_max)
-        {
-            current_max = p.y;
-        }
+        printf("The number of colors does not match the number of series in graph drawer\n");
     }
+
+    size_t newest_index = (sample_index-1);
+    if (sample_index<0){
+        sample_index+=series[0].size();
+    }
+
+    double earliest_time = series[0][sample_index].x;
+    double latest_time = series[0][newest_index].x;
+    // collect data
     if (std::abs(latest_time - earliest_time) < 0.001)
     {
-        Screen.printAt(width / 2, height / 2, "Not enough Data");
+        screen.printAt(width / 2, height / 2, "Not enough Data");
         return;
-    }
-    if (upper != lower)
-    {
-        current_min = lower;
-        current_max = upper;
     }
 
     if (border)
     {
-        Screen.setPenWidth(1);
-        Screen.setPenColor(vex::white);
-        Screen.setFillColor(bgcol);
-        Screen.drawRectangle(x, y, width, height);
+        screen.setPenWidth(1);
+        screen.setPenColor(vex::white);
+        screen.setFillColor(bgcol);
+        screen.drawRectangle(x, y, width, height);
     }
 
     double time_range = latest_time - earliest_time;
-    double sample_range = current_max - current_min;
-    double x_s = (double)x;
-    double y_s = (double)y + (double)height;
-    Screen.setPenWidth(2);
-    Screen.setPenColor(col);
-    for (int i = sample_index; i < samples.size() + sample_index - 1; i++)
+    double sample_range = upper - lower;
+    screen.setPenWidth(2);
+
+    for (int j = 0; j < series.size(); j++)
     {
-        point_t p = samples[i % samples.size()];
-        double x_pos = x_s + ((p.x - earliest_time) / time_range) * (double)width;
-        double y_pos = y_s + ((p.y - current_min) / sample_range) * (double)(-height);
+        double x_s = (double)x;
+        double y_s = (double)y + (double)height;
+        const std::vector<point_t> &samples = series[j];
 
-        point_t p2 = samples[(i + 1) % samples.size()];
-        double x_pos2 = x_s + ((p2.x - earliest_time) / time_range) * (double)width;
-        double y_pos2 = y_s + ((p2.y - current_min) / sample_range) * (double)(-height);
+        screen.setPenColor(cols[j]);
+        for (int i = sample_index; i < samples.size() + sample_index - 1; i++)
+        {
+            point_t p = samples[i % samples.size()];
+            double x_pos = x_s + ((p.x - earliest_time) / time_range) * (double)width;
+            double y_pos = y_s + ((p.y - lower) / sample_range) * (double)(-height);
 
-        Screen.drawLine((int)x_pos, (int)y_pos, (int)x_pos2, (int)y_pos2);
+            point_t p2 = samples[(i + 1) % samples.size()];
+            double x_pos2 = x_s + ((p2.x - earliest_time) / time_range) * (double)width;
+            double y_pos2 = y_s + ((p2.y - lower) / sample_range) * (double)(-height);
+
+            screen.drawLine((int)x_pos, (int)y_pos, (int)x_pos2, (int)y_pos2);
+        }
     }
 }

--- a/core/src/utils/pid.cpp
+++ b/core/src/utils/pid.cpp
@@ -31,11 +31,10 @@ double PID::update(double sensor_val)
 
   // Avoid a divide by zero error
   double d_term = 0;
-  if(time_delta != 0)
+  if (time_delta != 0)
     d_term = config.d * (get_error() - last_error) / time_delta;
-  else if(last_time != 0)
+  else if (last_time != 0)
     printf("(pid.cpp): Warning - running PID without a delay is just a P loop!\n");
-
 
   // P and D terms
   out = (config.p * get_error()) + d_term;
@@ -44,9 +43,9 @@ double PID::update(double sensor_val)
 
   // Only add to the accumulated error if the output is not saturated
   // aka "Integral Clamping" anti-windup technique
-  if ( !limits_exist || (limits_exist && (out < upper_limit && out > lower_limit)) )
+  if (!limits_exist || (limits_exist && (out < upper_limit && out > lower_limit)))
     accum_error += time_delta * get_error();
-  
+
   // I term
   out += config.i * accum_error;
 
@@ -55,9 +54,15 @@ double PID::update(double sensor_val)
 
   // Enable clamping if the limit is not 0
   if (limits_exist)
-    out = (out < lower_limit) ? lower_limit : (out > upper_limit) ? upper_limit : out;
+    out = (out < lower_limit) ? lower_limit : (out > upper_limit) ? upper_limit
+                                                                  : out;
 
   return out;
+}
+
+double PID::get_sensor_val()
+{
+  return sensor_val;
 }
 
 /**
@@ -88,7 +93,8 @@ double PID::get()
  */
 double PID::get_error()
 {
-  if (config.error_method==ERROR_TYPE::ANGULAR){
+  if (config.error_method == ERROR_TYPE::ANGULAR)
+  {
     return OdometryBase::smallest_angle(target, sensor_val);
   }
   return target - sensor_val;
@@ -108,7 +114,7 @@ void PID::set_target(double target)
 }
 
 /**
- * Set the limits on the PID out. The PID out will "clip" itself to be 
+ * Set the limits on the PID out. The PID out will "clip" itself to be
  * between the limits.
  */
 void PID::set_limits(double lower, double upper)
@@ -143,6 +149,7 @@ bool PID::is_on_target()
   return false;
 }
 
-Feedback::FeedbackType PID::get_type(){
-    return Feedback::FeedbackType::PIDType;
+Feedback::FeedbackType PID::get_type()
+{
+  return Feedback::FeedbackType::PIDType;
 }

--- a/include/core.h
+++ b/include/core.h
@@ -32,6 +32,7 @@
 #include "../core/include/utils/pure_pursuit.h"
 #include "../core/include/utils/trapezoid_profile.h"
 #include "../core/include/utils/vector2d.h"
+#include "../core/include/utils/serializer.h"
 
 // Base package
 #include "../core/include/robot_specs.h"

--- a/include/robot-config.h
+++ b/include/robot-config.h
@@ -25,10 +25,10 @@ extern robot_specs_t robot_cfg;
 extern OdometryTank odom;
 extern TankDrive drive_sys;
 
-extern double motor_volts;
+
 extern PID::pid_config_t cfg;
-extern GraphDrawer target_graph;
-extern GraphDrawer pos_graph;
+extern PID *pid_to_tune;
+
 extern Serializer *serializer;
 
 // ================ UTILS ================

--- a/include/robot-config.h
+++ b/include/robot-config.h
@@ -26,8 +26,6 @@ extern OdometryTank odom;
 extern TankDrive drive_sys;
 
 
-extern PID::pid_config_t cfg;
-extern PID *pid_to_tune;
 
 extern Serializer *serializer;
 

--- a/include/robot-config.h
+++ b/include/robot-config.h
@@ -26,6 +26,9 @@ extern OdometryTank odom;
 extern TankDrive drive_sys;
 
 extern double motor_volts;
+extern PID::pid_config_t cfg;
+extern GraphDrawer target_graph;
+extern GraphDrawer pos_graph;
 extern Serializer *serializer;
 
 // ================ UTILS ================

--- a/include/robot-config.h
+++ b/include/robot-config.h
@@ -25,6 +25,9 @@ extern robot_specs_t robot_cfg;
 extern OdometryTank odom;
 extern TankDrive drive_sys;
 
+extern double motor_volts;
+extern Serializer *serializer;
+
 // ================ UTILS ================
 
 void robot_init();

--- a/src/competition/opcontrol.cpp
+++ b/src/competition/opcontrol.cpp
@@ -7,7 +7,6 @@
  */
 void opcontrol()
 {
-    static vex::motor mot(vex::PORT1);
 
 
     while (imu.isCalibrating())
@@ -17,8 +16,6 @@ void opcontrol()
 
     // ================ INIT ================
     const static double target_pos = 90.0;
-    con.ButtonA.pressed([]()
-                        { mot.setPosition(0, vex::degrees); pid_to_tune->init(mot.position(vex::degrees), target_pos); });
     while (true)
     {
 #ifdef Tank
@@ -31,12 +28,6 @@ void opcontrol()
         double s = con.Axis1.position() / 100.0;
         drive_sys.drive_arcade(f, s);
 #endif
-        double pos = mot.position(vex::degrees);
-        pid_to_tune->update(pos);
-        if (con.ButtonA.pressing())
-            mot.spin(vex::fwd, pid_to_tune->get(), vex::volt);
-        else
-            mot.stop();
         vexDelay(10);
     }
 

--- a/src/competition/opcontrol.cpp
+++ b/src/competition/opcontrol.cpp
@@ -9,7 +9,6 @@ void opcontrol()
 {
     static vex::motor mot(vex::PORT1);
 
-    static Feedback *tf = new PID(cfg);
 
     while (imu.isCalibrating())
     {
@@ -19,8 +18,7 @@ void opcontrol()
     // ================ INIT ================
     const static double target_pos = 90.0;
     con.ButtonA.pressed([]()
-                        { mot.setPosition(0, vex::degrees); tf->init(mot.position(vex::degrees), target_pos); });
-    int tick = 0;
+                        { mot.setPosition(0, vex::degrees); pid_to_tune->init(mot.position(vex::degrees), target_pos); });
     while (true)
     {
 #ifdef Tank
@@ -34,19 +32,11 @@ void opcontrol()
         drive_sys.drive_arcade(f, s);
 #endif
         double pos = mot.position(vex::degrees);
-        if (tick % 2 == 0)
-        {
-            pos_graph.add_sample({(double)vex::timer::system(), pos});
-            target_graph.add_sample({(double)vex::timer::system(), target_pos});
-        }
-        tf->update(pos);
+        pid_to_tune->update(pos);
         if (con.ButtonA.pressing())
-        {
-            mot.spin(vex::fwd, tf->get(), vex::volt);
-        }
+            mot.spin(vex::fwd, pid_to_tune->get(), vex::volt);
         else
             mot.stop();
-        tick++;
         vexDelay(10);
     }
 

--- a/src/competition/opcontrol.cpp
+++ b/src/competition/opcontrol.cpp
@@ -7,6 +7,8 @@
  */
 void opcontrol()
 {
+    vex::motor mot(vex::PORT10);
+
     while (imu.isCalibrating())
     {
         vexDelay(20);
@@ -21,10 +23,18 @@ void opcontrol()
         double r = con.Axis2.position() / 100.0;
         drive_sys.drive_tank(l, r);
 #else
+
         double f = con.Axis2.position() / 100.0;
         double s = con.Axis1.position() / 100.0;
         drive_sys.drive_arcade(f, s);
 #endif
+
+        if (con.ButtonA.pressing())
+        {
+            mot.spin(vex::fwd, motor_volts, vex::volt);
+        }
+        else
+            mot.stop();
 
         vexDelay(10);
     }

--- a/src/robot-config.cpp
+++ b/src/robot-config.cpp
@@ -140,8 +140,6 @@ TankDrive drive_sys(left_motors, right_motors, robot_cfg, &odom);
 
 #endif
 
-PID::pid_config_t cfg = {.1, 0, 0, 0, 0.01, PID::ERROR_TYPE::LINEAR};
-PID *pid_to_tune = new PID(cfg);
 
 std::vector<screen::Page *> pages;
 
@@ -151,11 +149,9 @@ std::vector<screen::Page *> pages;
 void robot_init()
 {
 
-    odom.set_position({72, 62, 0});
     pages = {new AutoChooser({"Auto 1", "Auto 2", "Auto 3", "Auto 4"}),
              new screen::StatsPage(motor_names),
-             new screen::OdometryPage(odom, 12, 12, true),
-             new screen::PIDPage(pid_to_tune, "Motor")};
+             new screen::OdometryPage(odom, 12, 12, true)};
+    screen::start_screen(Brain.Screen, pages, 0);
     imu.calibrate();
-    screen::start_screen(Brain.Screen, pages, 3);
 }

--- a/src/robot-config.cpp
+++ b/src/robot-config.cpp
@@ -4,7 +4,6 @@ vex::controller con;
 
 Serializer *serializer = nullptr;
 
-
 #ifdef COMP_BOT
 
 inertial imu(PORT12);
@@ -142,21 +141,50 @@ TankDrive drive_sys(left_motors, right_motors, robot_cfg, &odom);
 // ================ UTILS ================
 
 #endif
-double motor_volts = 6.0;
+
+PID::pid_config_t cfg = {0, 0, 0, 0, 0.01, PID::ERROR_TYPE::LINEAR};
 
 std::vector<screen::Page *> pages;
 
-screen::SliderWidget motor_volt_slider(motor_volts, -12.0, 12.0, Rect{{60, 80}, {420, 120}}, "cata volts");
+screen::SliderWidget p_slider(cfg.p, -0.5, 0.5, Rect{{60, 20}, {210, 60}}, "P");
+screen::SliderWidget i_slider(cfg.i, -0.05, 0.05, Rect{{60, 80}, {180, 120}}, "I");
+screen::SliderWidget d_slider(cfg.d, -0.05, 0.05, Rect{{60, 140}, {180, 180}}, "D");
+
+screen::ButtonWidget zero_i([]()
+                            { cfg.i = 0; },
+                            Rect{{180, 80}, {220, 120}}, "0");
+screen::ButtonWidget zero_d([]()
+                            { cfg.d = 0; },
+                            Rect{{180, 140}, {220, 180}}, "0");
+
+GraphDrawer target_graph(Brain.Screen, 40, "", "", vex::color(255, 0, 0), true, -30, 120);
+GraphDrawer pos_graph(Brain.Screen, 40, "", "", vex::color(0, 255, 0), false, -30, 120);
 
 auto updatef = [](bool was_pressed, int x, int y)
 {
-    motor_volt_slider.update(was_pressed, x, y);
-    serializer->set_double("cata_volts", motor_volts);
+    if (p_slider.update(was_pressed, x, y))
+        serializer->set_double("motor_p", cfg.p);
+
+    if (i_slider.update(was_pressed, x, y))
+        serializer->set_double("motor_i", cfg.i);
+
+    if (d_slider.update(was_pressed, x, y))
+        serializer->set_double("motor_d", cfg.d);
+
+    zero_i.update(was_pressed, x, y);
+    zero_d.update(was_pressed, x, y);
 };
 
 auto drawf = [](vex::brain::lcd &scr, bool first_draw, unsigned int frame_number)
 {
-    motor_volt_slider.draw(scr, first_draw, frame_number);
+    p_slider.draw(scr, first_draw, frame_number);
+    i_slider.draw(scr, first_draw, frame_number);
+    d_slider.draw(scr, first_draw, frame_number);
+    zero_i.draw(scr, first_draw, frame_number);
+    zero_d.draw(scr, first_draw, frame_number);
+
+    target_graph.draw(230, 20, 200, 200);
+    pos_graph.draw(230, 20, 200, 200);
 };
 
 /**
@@ -165,9 +193,15 @@ auto drawf = [](vex::brain::lcd &scr, bool first_draw, unsigned int frame_number
 void robot_init()
 {
     serializer = new Serializer("cata_params.ser");
-    motor_volts = serializer->double_or("cata_volts", 6.0);
+
+    cfg.p = serializer->double_or("motor_p", 0.0);
+    cfg.i = serializer->double_or("motor_i", 0.0);
+    cfg.d = serializer->double_or("motor_d", 0.0);
+
+    fprintf(stderr, "AHHHHHHHHH");
+
     odom.set_position({72, 62, 0});
     pages = {new AutoChooser({"Auto 1", "Auto 2", "Auto 3", "Auto 4"}), new screen::StatsPage(motor_names), new screen::OdometryPage(odom, 12, 12, true), new screen::FunctionPage(updatef, drawf)};
     imu.calibrate();
-    screen::start_screen(Brain.Screen, pages, 2);
+    screen::start_screen(Brain.Screen, pages, 3);
 }

--- a/src/robot-config.cpp
+++ b/src/robot-config.cpp
@@ -151,13 +151,11 @@ std::vector<screen::Page *> pages;
 void robot_init()
 {
 
-
     odom.set_position({72, 62, 0});
     pages = {new AutoChooser({"Auto 1", "Auto 2", "Auto 3", "Auto 4"}),
              new screen::StatsPage(motor_names),
              new screen::OdometryPage(odom, 12, 12, true),
-             new screen::PIDPage(pid_to_tune, "a motor", []()
-                                 { printf("CHANGED\n"); })};
+             new screen::PIDPage(pid_to_tune, "Motor")};
     imu.calibrate();
     screen::start_screen(Brain.Screen, pages, 3);
 }

--- a/src/robot-config.cpp
+++ b/src/robot-config.cpp
@@ -140,7 +140,7 @@ TankDrive drive_sys(left_motors, right_motors, robot_cfg, &odom);
 
 #endif
 
-PID::pid_config_t cfg = {0, 0, 0, 0, 0.01, PID::ERROR_TYPE::LINEAR};
+PID::pid_config_t cfg = {.1, 0, 0, 0, 0.01, PID::ERROR_TYPE::LINEAR};
 PID *pid_to_tune = new PID(cfg);
 
 std::vector<screen::Page *> pages;
@@ -151,13 +151,12 @@ std::vector<screen::Page *> pages;
 void robot_init()
 {
 
-    fprintf(stderr, "AHHHHHHHHH");
 
     odom.set_position({72, 62, 0});
     pages = {new AutoChooser({"Auto 1", "Auto 2", "Auto 3", "Auto 4"}),
              new screen::StatsPage(motor_names),
              new screen::OdometryPage(odom, 12, 12, true),
-             new screen::PIDPage(cfg, pid_to_tune, "a motor", []()
+             new screen::PIDPage(pid_to_tune, "a motor", []()
                                  { printf("CHANGED\n"); })};
     imu.calibrate();
     screen::start_screen(Brain.Screen, pages, 3);

--- a/src/robot-config.cpp
+++ b/src/robot-config.cpp
@@ -167,7 +167,7 @@ void robot_init()
     serializer = new Serializer("cata_params.ser");
     motor_volts = serializer->double_or("cata_volts", 6.0);
     odom.set_position({72, 62, 0});
-    pages = {new screen::StatsPage(motor_names), new screen::OdometryPage(odom, 12, 12, true), new screen::FunctionPage(updatef, drawf)};
+    pages = {new AutoChooser({"Auto 1", "Auto 2", "Auto 3", "Auto 4"}), new screen::StatsPage(motor_names), new screen::OdometryPage(odom, 12, 12, true), new screen::FunctionPage(updatef, drawf)};
     imu.calibrate();
     screen::start_screen(Brain.Screen, pages, 2);
 }


### PR DESCRIPTION

# Screen
[Header](https://github.com/RIT-VEX-U/Core/blob/master/include/subsystems/screen.h) | [Source](https://github.com/RIT-VEX-U/Core/blob/master/src/subsystems/screen.cpp)
The Screen system (`screen.h`) allows for a slideshow like way of showing information on the brain screen.

to start a screen task: 
```c++
std::vector<screen::Page *> pages = {...}

screen::start_screen(Brain.Screen, pages);
```

## Builtin Widgets

These button and slider are included for your page development needs

### Slider
Updates a double based off of a slider on screen

```c++
// at creation
double val = 0;
Slider slider =  Slider(val, 0.0, 0.5, Rect{{60, 20}, {210, 60}}, "Val"),

// in the update() function of the page
if (slider.update(was_pressed, x, y)){
    printf("updated\n");
]

// in the draw() function of the page
slider.draw(scr, first_draw, frame_number);

```

## Builtin Pages
The `screen.h` file has some builtin screens that are used in pretty much every competition.

### OdometryPage

The Odometry Page presents the robots state estimation alongside a pretty map of the field.
The field map must be loaded on the SD card at `vex_field_240p.png`. If it is not, only a textual representation of the pose will be shown
Additionally, the constructor takes a width and height parameter that defines the bounding box of the robot. This will be used in the visualization. 

```c++
OdometryTank odom{left_motors, right_motors, robot_cfg};
pages = {new screen::OdometryPage(odom, 12, 12, true)};

```

![odom](https://github.com/RIT-VEX-U/Core/assets/44383226/887c5a87-334b-4bff-b3cc-f60a509c525d)



### StatsPage

The Stats page presents information about motors and the battery.
It shows the temperature, port, name and plugged-in-ness of motors and the temperature, percentage and voltage of the battery.
To create a StatsPage, you  first need a `std::map` of names and motors, then construct the page with that map.  


```c++
std::map<std::string, vex::motor &> motor_names = {
    {"left f", left_front},
    {"left b", left_middle},

    {"right f", right_front},
    {"right b", right_back},
};
pages = {new screen::StatsPage(motor_names)};
```
![motor_screen](https://github.com/RIT-VEX-U/Core/assets/44383226/f45686f1-fb3f-4a4a-9d66-3d695bf9c503)


### Autochooser

[Header](https://github.com/RIT-VEX-U/Core/blob/master/include/utils/auto_chooser.h) | [Source](https://github.com/RIT-VEX-U/Core/blob/master/src/utils/auto_chooser.cpp)

During a season, we usually code between 4 and 6 autonomous programs. Most teams will change their entire robot program as a way of choosing autonomi, but this may cause issues if you have an emergency patch to upload during a competition. This class was built as a way of using the robot screen to list autonomous programs, and the touchscreen to select them.


```c++
chooser = new AutoChooser({"Auto 1", "Auto 2", "Auto 3", "Auto 4"}

pages = {chooser),
screen.run(Brain.Screen, pages);
```

Then, at the start of `autonomous` you can call 
`chooser->get_choice()` which will return an index to the selected one. By default, the first choice is selected


![auto_screen](https://github.com/RIT-VEX-U/Core/assets/44383226/625cff54-6c10-4a46-9031-e93ced793d41)

### Pid Tuning Page

A page that allows the tuning of an arbitrary pid controller

```c++
PID pid_con = new PID(...);
pages = {new PIDPage(pid_con, "My Pid")};
```
then when tuning simply use your PID control as usual. Whenever you make an adjustment on the screen, the PID controller will automatically update. 

![pid](https://github.com/RIT-VEX-U/Core/assets/44383226/3ba489ba-a85e-46f7-b193-820cbf33b0f1)

